### PR TITLE
Exit inside parentheses doesn't exit script

### DIFF
--- a/src/arch.sh
+++ b/src/arch.sh
@@ -5,7 +5,7 @@
 #DO NOT RUN THIS YOURSELF because Step 1 is it reformatting /dev/sda WITHOUT confirmation,
 #which means RIP in peace qq your data unless you've already backed up all of your drive.
 
-pacman -S --noconfirm dialog || (echo "Error at script start: Are you sure you're running this as the root user? Are you sure you have an internet connection?" && exit)
+pacman -S --noconfirm dialog || { echo "Error at script start: Are you sure you're running this as the root user? Are you sure you have an internet connection?"; exit; }
 RED='\033[0;31m'
 BLUE='\033[0;34m'
 NC='\033[0m'

--- a/src/larbs.sh
+++ b/src/larbs.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-pacman -S --noconfirm --needed dialog || (echo "Error at script start: Are you sure you're running this as the root user? Are you sure you're using an Arch-based distro? ;-) Are you sure you have an internet connection?" && exit)
-
+pacman -S --noconfirm --needed dialog || { echo "Error at script start: Are you sure you're running this as the root user? Are you sure you're using an Arch-based distro? ;-) Are you sure you have an internet connection?"; exit; }
 dialog --title "Welcome!" --msgbox "Welcome to Luke's Auto-Rice Bootstrapping Script!\n\nThis script will automatically install a fully-featured i3wm Arch Linux desktop, which I use as my main machine.\n\n-Luke" 10 60
 
 name=$(dialog --no-cancel --inputbox "First, please enter a name for the user account." 10 60 3>&1 1>&2 2>&3 3>&1)
@@ -36,7 +35,7 @@ choices=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
 
 let="\(\|[a-z]\|$(echo $choices | sed -e "s/ /\\\|/g")\)"
 
-dialog --title "Let's get this party started!" --msgbox "The rest of the installation will now be totally automated, so you can sit back and relax.\n\nIt will take some time, but when done, you can relax even more with your complete system.\n\nNow just press <OK> and the system will begin installation!" 13 60 || (clear && exit)
+dialog --title "Let's get this party started!" --msgbox "The rest of the installation will now be totally automated, so you can sit back and relax.\n\nIt will take some time, but when done, you can relax even more with your complete system.\n\nNow just press <OK> and the system will begin installation!" 13 60 || { clear; exit; }
 
 clear
 


### PR DESCRIPTION
Several error conditions were resulting in a message printed and "exit"
being called, however expressions inside parentheses are executed in a
subshell; consequently the *subshell* would exit but the parent shell
continued running the script.

https://stackoverflow.com/questions/19886797/exit-inside-parentheses-doesnt-exit-script