### PR TITLE
`xorg-xprop` instead of `xprop`

### DIFF
--- a/progs.csv
+++ b/progs.csv
@@ -10,7 +10,7 @@
 ,arandr,"is a UI for screen adjustment."
 ,calcurse,"is a lightweight terminal-based calendar."
 ,xcompmgr,"is for transparency and removing screen-tearing."
-,xprop,"is a tool for detecting window properties."
+,xorg-xprop,"is a tool for detecting window properties."
 ,dosfstools,"allows your computer to access dos-like filesystems."
 ,libnotify,"allows desktop notifications."
 ,dunst,"is a suckless notification system."


### PR DESCRIPTION
It should be `xorg-xprop` instead of `xprop`:
https://www.archlinux.org/packages/extra/x86_64/xorg-xprop/