### PR TITLE
Pacman hook to remove older package versions

### DIFF
--- a/larbs.sh
+++ b/larbs.sh
@@ -208,6 +208,20 @@ serviceinit NetworkManager cronie
 # Most important command! Get rid of the beep!
 systembeepoff
 
+# keep only latest 3 versions of packages
+cat > /etc/pacman.d/hooks/pacman-cleanup.hook << EOF
+[Trigger]
+Type = Package
+Operation = Remove
+Operation = Install
+Operation = Upgrade
+Target = *
+[Action]
+Description = Keeps only the latest 3 versions of packages
+When = PostTransaction
+Exec = /usr/bin/paccache -rk3
+EOF
+
 # This line, overwriting the `newperms` command above will allow the user to run
 # serveral important commands, `shutdown`, `reboot`, updating, etc. without a password.
 newperms "%wheel ALL=(ALL) ALL #LARBS


### PR DESCRIPTION
A pacman hook to clean pacman's cache. Keeps only the 3 latest versions in case a downgrade is needed and removes older versions to remove clutter. 

However some people say that you shouldn't ever clear pacman's cache. Its just a suggestion.
(Also I think I failed my first PR. If the same request shows up twice sorry.)