### PR TITLE
add gnome-themes-extra for adwaita-dark

### DIFF
--- a/progs.csv
+++ b/progs.csv
@@ -21,6 +21,7 @@
 ,ffmpeg,"can record and splice video and audio on the command line."
 ,gnome-keyring,"serves as the system keyring."
 A,gtk-theme-arc-gruvbox-git,"gives the dark GTK theme used in LARBS."
+,gnome-themes-extra,provides the Adwaita-dark theme used in GTK3 apps(e.g firefox).
 ,neovim,"an tidier vim with some useful features"
 ,i3blocks,"is the status bar."
 ,i3lock,"is the screen lock."


### PR DESCRIPTION
This is used by GTK3 apps such as Firefox, I don't know if other packages pull this as a dependency in arch but it didn't install in Manjaro 