### PR TITLE
Handling private repositories

### DIFF
--- a/larbs.sh
+++ b/larbs.sh
@@ -192,7 +192,7 @@ adduserandpass || error "Error adding username and/or password."
 refreshkeys || error "Error automatically refreshing Arch keyring. Consider doing so manually."
 
 dialog --title "LARBS Installation" --infobox "Installing \`basedevel\` , \`git\` and \`expect\` for installing other software." 5 70
-pacman --noconfirm --needed -S base-devel git >/dev/null 2>&1
+pacman --noconfirm --needed -S base-devel git expect >/dev/null 2>&1
 [ -f /etc/sudoers.pacnew ] && cp /etc/sudoers.pacnew /etc/sudoers # Just in case
 
 # Allow user to run sudo without password. Since AUR programs must be installed


### PR DESCRIPTION
Because GitHub now allows for free private repositories, more and more people use them to store their configs and applications that may contain sensitive data.
These changes to your script allow for non-intrusive handling of these private repositories so they can all be installed without any additional prompts.