### PR TITLE
Strip '.git' from working dir when cloning repos

### DIFF
--- a/larbs.sh
+++ b/larbs.sh
@@ -101,7 +101,7 @@ maininstall() { # Installs all needed programs from main repo.
 	}
 
 gitmakeinstall() {
-	progname="$(basename "$1")"
+	progname="$(basename "$1" .git)"
 	dir="$repodir/$progname"
 	dialog --title "LARBS Installation" --infobox "Installing \`$progname\` ($n of $total) via \`git\` and \`make\`. $(basename "$1") $2" 5 70
 	sudo -u "$name" git clone --depth 1 "$1" "$dir" >/dev/null 2>&1 || { cd "$dir" || return ; sudo -u "$name" git pull --force origin master;}


### PR DESCRIPTION
Using `.git` suffix generally signifies the clone is bare, which is not the case here.