### PR TITLE
fix the "tap-to-click" enabler (40-libinput.conf)

### DIFF
--- a/larbs.sh
+++ b/larbs.sh
@@ -220,14 +220,14 @@ sudo -u "$name" mkdir -p "/home/$name/.cache/zsh/"
 dbus-uuidgen > /var/lib/dbus/machine-id
 
 # Tap to click
-[ ! -f /etc/X11/xorg.conf.d/40-libinput.conf ] && echo "Section "InputClass"
+[ ! -f /etc/X11/xorg.conf.d/40-libinput.conf ] && printf 'Section "InputClass"
         Identifier "libinput touchpad catchall"
         MatchIsTouchpad "on"
         MatchDevicePath "/dev/input/event*"
         Driver "libinput"
 	# Enable left mouse button by tapping
 	Option "Tapping" "on"
-EndSection" > /etc/X11/xorg.conf.d/40-libinput.conf
+EndSection' > /etc/X11/xorg.conf.d/40-libinput.conf
 
 # Fix fluidsynth/pulseaudio issue.
 grep -q "OTHER_OPTS='-a pulseaudio -m alsa_seq -r 48000'" /etc/conf.d/fluidsynth ||


### PR DESCRIPTION
1. We need them quotes (`"`) where they are specified in the `40-libinput.conf` file, but if you use `echo` and echo surround the output string itself with the double quotes (`"`), the ones inside it will get removed. fixed.

pretty lucky that I just happened to be a part of the convo in https://github.com/LukeSmithxyz/LARBS/issues/118 to get a notification & thus notice & try out https://github.com/LukeSmithxyz/LARBS/commit/1d8b03595abbff088d79c0dc22d3e43b128dcb97 - Xorg reported an error and couldn't launch i3 until this patch, so here we are:D

2. (misc since it doesn't matter as much here but anyhow) `echo` shouldn't be used in any scripts anyway because it's unpredictable, and `printf` should be preferred (imo, anyway. Just mind that you there's no extra newline so if you need one/expected one from echo - add it yourself):

```sh
# unpredictable echo (with newline by default, though not always)
$ echo "omg larbs so kewl"
omg larbs so kewl
$
```

```sh
# predictable printf without a newline by default
$ printf "omg larbs so kewl"
omg larbs so kewl $
```

```sh
# predictable printf with a newline because you said so
$ printf "omg larbs so kewl\n"
omg larbs so kewl
$
```

take care!