### PR TITLE
Use tee(1) to copy from stdin to stdout

### DIFF
--- a/larbs.sh
+++ b/larbs.sh
@@ -220,10 +220,10 @@ sudo -u "$name" mkdir -p "/home/$name/.cache/zsh/"
 dbus-uuidgen > /var/lib/dbus/machine-id
 
 # Tap to click
-T2C_PATCH="/etc/X11/xorg.conf.d/40-libinput.conf"
+touch_patch="/etc/X11/xorg.conf.d/40-libinput.conf"
 
-[ ! -f "$T2C_PATH" ] && {
-    tee "$T2C_PATCH" <<! >/dev/null
+[ ! -f "$touch_patch" ] && {
+    tee "$touch_patch" <<! >/dev/null
 Section "InputClass"
     Identifier "libinput touchpad catchall"
     MatchIsTouchpad "on"

--- a/larbs.sh
+++ b/larbs.sh
@@ -220,14 +220,20 @@ sudo -u "$name" mkdir -p "/home/$name/.cache/zsh/"
 dbus-uuidgen > /var/lib/dbus/machine-id
 
 # Tap to click
-[ ! -f /etc/X11/xorg.conf.d/40-libinput.conf ] && printf 'Section "InputClass"
-        Identifier "libinput touchpad catchall"
-        MatchIsTouchpad "on"
-        MatchDevicePath "/dev/input/event*"
-        Driver "libinput"
-	# Enable left mouse button by tapping
-	Option "Tapping" "on"
-EndSection' > /etc/X11/xorg.conf.d/40-libinput.conf
+T2C_PATCH="/etc/X11/xorg.conf.d/40-libinput.conf"
+
+[ ! -f "$T2C_PATH" ] && {
+    tee "$T2C_PATCH" <<! >/dev/null
+Section "InputClass"
+    Identifier "libinput touchpad catchall"
+    MatchIsTouchpad "on"
+    MatchDevicePath "/dev/input/event*"
+    Driver "libinput"
+    # Enable left mouse button by tapping
+    Option "Tapping" "on"
+EndSection
+!
+}
 
 # Fix fluidsynth/pulseaudio issue.
 grep -q "OTHER_OPTS='-a pulseaudio -m alsa_seq -r 48000'" /etc/conf.d/fluidsynth ||


### PR DESCRIPTION
Use this instead of `printf`;
`tee(1)` also offers the `-a` flag to append, perhaps that is better instead of checking if the file exists; but it may dupe user's already set patch...

`/dev/null` can be left out, just there for the sake of not cluttering the screen

The variable `touch_patch` should not bed needed, but since it is used more than once, why not a variable

References [tee(1)](https://man.openbsd.org/tee)