### PR TITLE
Use the "A" tag for abook

### DIFF
--- a/progs.csv
+++ b/progs.csv
@@ -32,7 +32,7 @@ A,brave-bin,"is an elegant browser with built-in adblocking, tor and other featu
 ,pamixer,"is a command-line audio interface."
 A,sc-im,"is an Excel-like terminal spreadsheet manager."
 ,maim,"can take quick screenshots at your request."
-,abook,"is an offline addressbook usable by neomutt."
+A,abook,"is an offline addressbook usable by neomutt."
 ,unclutter,"hides an inactive mouse."
 ,unrar,"extracts rar's."
 ,unzip,"unzips zips."


### PR DESCRIPTION
Abook was moved to the AUR on 2021-05-08: https://aur.archlinux.org/packages/abook/
