### PR TITLE
Prefer pkill over killall

### DIFF
--- a/larbs.sh
+++ b/larbs.sh
@@ -242,7 +242,7 @@ grep -q "OTHER_OPTS='-a pulseaudio -m alsa_seq -r 48000'" /etc/conf.d/fluidsynth
 	echo "OTHER_OPTS='-a pulseaudio -m alsa_seq -r 48000'" >> /etc/conf.d/fluidsynth
 
 # Start/restart PulseAudio.
-killall pulseaudio; sudo -u "$name" pulseaudio --start
+pkill -15 -x 'pulseaudio'; sudo -u "$name" pulseaudio --start
 
 # This line, overwriting the `newperms` command above will allow the user to run
 # serveral important commands, `shutdown`, `reboot`, updating, etc. without a password.


### PR DESCRIPTION
[`pkill(1)`](https://man.openbsd.org/pkill) ships out of the box on more systems than `killall`. Void Linux is an example.