### PR TITLE
Enable parallel downloads for Pacman

### DIFF
--- a/larbs.sh
+++ b/larbs.sh
@@ -185,9 +185,12 @@ adduserandpass || error "Error adding username and/or password."
 # in a fakeroot environment, this is required for all builds with AUR.
 newperms "%wheel ALL=(ALL) NOPASSWD: ALL"
 
-# Make pacman and paru colorful and adds eye candy on the progress bar because why not.
+# Make pacman and AUR helper colorful and adds eye candy on the progress bar because why not.
 grep -q "^Color" /etc/pacman.conf || sed -i "s/^#Color$/Color/" /etc/pacman.conf
 grep -q "ILoveCandy" /etc/pacman.conf || sed -i "/#VerbosePkgLists/a ILoveCandy" /etc/pacman.conf
+# Enable parallel downloads for pacman.
+grep -q "^#ParallelDownloads = 8$" /etc/pacman.conf \
+    && sed -i "s/^#ParallelDownloads = 8$/ParallelDownloads = 5/" /etc/pacman.conf
 
 # Use all cores for compilation.
 sed -i "s/-j2/-j$(nproc)/;s/^#MAKEFLAGS/MAKEFLAGS/" /etc/makepkg.conf


### PR DESCRIPTION
I'm currently experimenting with [pacman's parallel downloads](https://wiki.archlinux.org/title/Pacman#Enabling_parallel_downloads) with much success. There are a few opinions about the actual value of the simultaneous downloads, some suggest the value of `nproc` is fine but there's really not much documentation on the wiki.

Because of this lack of info, I've decided to stick the sane default provided by the wiki (**5 parallel downloads**). Along these lines, I dislike having to hardcode look for `"^#ParallelDownloads = 8$"` (maybe this default value will change in the future) but the `sed` would fail anyways because of the failed `grep` before.

NOTE 1 : After finishing this writing I noticed Brodie [made a video about it](https://youtu.be/p8e3uEAsQO8) not too long ago. Great demo keeping in mind the wiki is void on this topic.

NOTE 2: My `grep` and `sed` violate the convention of the other 2 above, it's the same but just inverted, I find it easier to read `&&`s than `||`s.