### PR TITLE
Fixing AUR helper

### DIFF
--- a/larbs.sh
+++ b/larbs.sh
@@ -188,7 +188,7 @@ grep -q "ILoveCandy" /etc/pacman.conf || sed -i "/#VerbosePkgLists/a ILoveCandy"
 # Use all cores for compilation.
 sed -i "s/-j2/-j$(nproc)/;s/^#MAKEFLAGS/MAKEFLAGS/" /etc/makepkg.conf
 
-manualinstall yay-bin || error "Failed to install AUR helper."
+manualinstall yay || error "Failed to install AUR helper."
 
 # The command that does all the installing. Reads the progs.csv file and
 # installs each needed program the way required. Be sure to run this only after

--- a/larbs.sh
+++ b/larbs.sh
@@ -78,11 +78,7 @@ manualinstall() { # Installs $1 manually if not installed. Used only for AUR hel
 	dialog --infobox "Installing \"$1\", an AUR helper..." 4 50
 	cd /tmp || exit 1
 	rm -rf /tmp/"$1"*
-	curl -sO https://aur.archlinux.org/cgit/aur.git/snapshot/"$1".tar.gz &&
-	sudo -u "$name" tar -xvf "$1".tar.gz >/dev/null 2>&1 &&
-	cd "$1" &&
-	sudo -u "$name" makepkg --noconfirm -si >/dev/null 2>&1 || return 1
-	cd /tmp || return 1) ;}
+	git clone https://aur.archlinux.org/yay.git && cd yay && makepkg -si
 
 maininstall() { # Installs all needed programs from main repo.
 	dialog --title "LARBS Installation" --infobox "Installing \`$1\` ($n of $total). $1 $2" 5 70


### PR DESCRIPTION
This is my potential fix to a current issue where the manualinstall() function causes the install to break i have removed the code where it uses curl to install yay-bin and have instead opted to use git clone to pull yay from the AUR this should hopefully solve the problem of the install crashing due to it failing to install