### PR TITLE
updates yay-bin to yay to fix bug

### DIFF
--- a/larbs.sh
+++ b/larbs.sh
@@ -191,7 +191,7 @@ grep -q "ILoveCandy" /etc/pacman.conf || sed -i "/#VerbosePkgLists/a ILoveCandy"
 # Use all cores for compilation.
 sed -i "s/-j2/-j$(nproc)/;s/^#MAKEFLAGS/MAKEFLAGS/" /etc/makepkg.conf
 
-manualinstall yay-bin || error "Failed to install AUR helper."
+manualinstall yay || error "Failed to install AUR helper."
 
 # The command that does all the installing. Reads the progs.csv file and
 # installs each needed program the way required. Be sure to run this only after


### PR DESCRIPTION
the link to the precompiled yay on the aur returns a 404 error. changing the script to install yay instead fixes this.

[https://github.com/LukeSmithxyz/LARBS/issues/382](url)