### PR TITLE
Fix auto-enable arch repos

### DIFF
--- a/larbs.sh
+++ b/larbs.sh
@@ -77,6 +77,7 @@ refreshkeys() { \
 					echo "[$repo]
 Include = /etc/pacman.d/mirrorlist-arch" >> /etc/pacman.conf
 			done
+			pacman -Sy >/dev/null 2>&1
 			pacman-key --populate archlinux
 			;;
 	esac ;}


### PR DESCRIPTION
After enabling arch repos,  need to download database files.  Otherwise, calls to
`pacman -S` return errors that are suppressed by redirection to /dev/null.

Error Message:

```sh
warning: database file for 'extra' does not exist (use "-Sy" to download)
error: failed to prepare transcation (could not find database)
```

Fixes: https://github.com/LukeSmithxyz/LARBS/issues/393