### PR TITLE
Fix ParallelDownloads

### DIFF
--- a/larbs.sh
+++ b/larbs.sh
@@ -198,7 +198,7 @@ newperms "%wheel ALL=(ALL) NOPASSWD: ALL"
 
 # Make pacman colorful, concurrent downloads and Pacman eye-candy.
 grep -q "ILoveCandy" /etc/pacman.conf || sed -i "/#VerbosePkgLists/a ILoveCandy" /etc/pacman.conf
-sed -i "s/^#ParallelDownloads = 8$/ParallelDownloads = 5/;s/^#Color$/Color/" /etc/pacman.conf
+sed -i "s/^#ParallelDownloads.*$/ParallelDownloads = 5/;s/^#Color$/Color/" /etc/pacman.conf
 
 # Use all cores for compilation.
 sed -i "s/-j2/-j$(nproc)/;s/^#MAKEFLAGS/MAKEFLAGS/" /etc/makepkg.conf


### PR DESCRIPTION
It looks like new Arch installations have a line `#ParallelDownloads = 5` in `/etc/pacman.conf`, and larbs.sh doesn't change it to `ParallelDownloads = 5` because it looks for a line `#ParallelDownloads = 8`

It might be a good idea to change sed regex to `^#ParallelDownloads.*$` so that it can handle lines like
```
#ParallelDownloads = 5
#ParallelDownloads = 8
#ParallelDownloads<any other value>
```