### PR TITLE
cleanup sed commands for pacman paralleldownloads, colors

### DIFF
--- a/larbs.sh
+++ b/larbs.sh
@@ -202,7 +202,7 @@ grep -q "ILoveCandy" /etc/pacman.conf || sed -i "/#VerbosePkgLists/a ILoveCandy"
 sed -i "s/^#ParallelDownloads.*/ParallelDownloads = 5/;/Color$/s/^#//" /etc/pacman.conf
 
 # Use all cores for compilation.
-sed -i "s/-j2/-j$(nproc)/;s/^#MAKEFLAGS/MAKEFLAGS/" /etc/makepkg.conf
+sed -i "s/-j2/-j$(nproc)/;/MAKEFLAGS/s/^#//" /etc/makepkg.conf
 
 manualinstall yay || error "Failed to install AUR helper."
 

--- a/larbs.sh
+++ b/larbs.sh
@@ -199,7 +199,7 @@ newperms "%wheel ALL=(ALL) NOPASSWD: ALL"
 
 # Make pacman colorful, concurrent downloads and Pacman eye-candy.
 grep -q "ILoveCandy" /etc/pacman.conf || sed -i "/#VerbosePkgLists/a ILoveCandy" /etc/pacman.conf
-sed -i "s/^#ParallelDownloads.*$/ParallelDownloads = 5/;s/^#Color$/Color/" /etc/pacman.conf
+sed -i "s/^#ParallelDownloads.*/ParallelDownloads = 5/;/Color$/s/^#//" /etc/pacman.conf
 
 # Use all cores for compilation.
 sed -i "s/-j2/-j$(nproc)/;s/^#MAKEFLAGS/MAKEFLAGS/" /etc/makepkg.conf


### PR DESCRIPTION
because the pattern ends with `.*` the `$` is useless. also made the sed for uncommenting "Colors" slightly shorter by using `/<pattern>$/s/^#//` instead of `s/^#<pattern>$/<pattern>/`