### PR TITLE
revert 6251644, and partially 1bd9a35

### DIFF
--- a/larbs.sh
+++ b/larbs.sh
@@ -199,10 +199,10 @@ newperms "%wheel ALL=(ALL) NOPASSWD: ALL"
 
 # Make pacman colorful, concurrent downloads and Pacman eye-candy.
 grep -q "ILoveCandy" /etc/pacman.conf || sed -i "/#VerbosePkgLists/a ILoveCandy" /etc/pacman.conf
-sed -i "/^#ParallelDownloads/s/=.*/= 5/;/Color$/s/^#//" /etc/pacman.conf
+sed -i "/^#ParallelDownloads/s/=.*/= 5/;s/^#Color$/Color/" /etc/pacman.conf
 
 # Use all cores for compilation.
-sed -i "s/-j2/-j$(nproc)/;/MAKEFLAGS/s/^#//" /etc/makepkg.conf
+sed -i "s/-j2/-j$(nproc)/;/^#MAKEFLAGS/s/^#//" /etc/makepkg.conf
 
 manualinstall yay || error "Failed to install AUR helper."
 


### PR DESCRIPTION
in 6251644, the shortening of the sed for uncommenting MAKEFLAGS also made it less specific, acting on lines containing "MAKEFLAGS" instead of "^#MAKEFLAGS". the change to the pacman color sed in 1bd9a35 once given the same correction only saves 1 character over the previous commit's more readable expression where "Color" appears twice, so it's reverted to that.