### PR TITLE
fix ParallelDownloads regex, add -E for 2 seds, shorten pacman color regex

### DIFF
--- a/larbs.sh
+++ b/larbs.sh
@@ -129,7 +129,7 @@ installationloop() { \
 	aurinstalled=$(pacman -Qqm)
 	while IFS=, read -r tag program comment; do
 		n=$((n+1))
-		echo "$comment" | grep -q "^\".*\"$" && comment="$(echo "$comment" | sed "s/\(^\"\|\"$\)//g")"
+		echo "$comment" | grep -q "^\".*\"$" && comment="$(echo "$comment" | sed -E "s/(^\"|\"$)//g")"
 		case "$tag" in
 			"A") aurinstall "$program" "$comment" ;;
 			"G") gitmakeinstall "$program" "$comment" ;;
@@ -199,7 +199,7 @@ newperms "%wheel ALL=(ALL) NOPASSWD: ALL"
 
 # Make pacman colorful, concurrent downloads and Pacman eye-candy.
 grep -q "ILoveCandy" /etc/pacman.conf || sed -i "/#VerbosePkgLists/a ILoveCandy" /etc/pacman.conf
-sed -i "/^#ParallelDownloads/s/=.*/= 5/;s/^#Color$/Color/" /etc/pacman.conf
+sed -Ei "s/^#(ParallelDownloads).*/\1 = 5/;/^#Color$/s/#//" /etc/pacman.conf
 
 # Use all cores for compilation.
 sed -i "s/-j2/-j$(nproc)/;/^#MAKEFLAGS/s/^#//" /etc/makepkg.conf


### PR DESCRIPTION
change ParallelDownloads regex to `s/^#(ParallelDownloads).*/\1 = 5/` as `/^#ParallelDownloads/s/=.*/= 5/` changes the value to 5 but fails to uncomment it. use -E for the 2 seds using grouping so the parenthesis and `|` don't have to be escaped, and shortened the pacman color sed by 2 chars (`s/^#Color$/Color/` to `/^#Color$/s/#//`)

**If you installed LARBS on commit 231f3b2 or later, make sure "ParallelDownloads" is uncommented in** `/etc/pacman.conf`