### PR TITLE
default group wheel ...

### DIFF
--- a/larbs.sh
+++ b/larbs.sh
@@ -57,7 +57,7 @@ preinstallmsg() { \
 adduserandpass() { \
 	# Adds user `$name` with password $pass1.
 	dialog --infobox "Adding user \"$name\"..." 4 50
-	useradd -m -G wheel -s /bin/zsh "$name" >/dev/null 2>&1 ||
+	useradd -m -g wheel -s /bin/zsh "$name" >/dev/null 2>&1 ||
 	usermod -a -G wheel "$name" && mkdir -p /home/"$name" && chown "$name":wheel /home/"$name"
 	export repodir="/home/$name/.local/src"; mkdir -p "$repodir"; chown -R "$name":wheel "$(dirname "$repodir")"
 	echo "$name:$pass1" | chpasswd


### PR DESCRIPTION
useradd -a -G creates default user and default group same as username, and then appends wheel as a usergroup, while reading rest of the script, the intent is obviously to have wheel as the default usergroup due to chowning downloaded dotfiles and src files to username:wheel ...

current settings result in file permissions of files downloaded during install to be owned by username:wheel but newly created files are still owned by username:username due to -G flag ... use -g instead to set wheel as default usergroup