### PR TITLE
Add [universe] repo for artix-archlinux-support

### DIFF
--- a/larbs.sh
+++ b/larbs.sh
@@ -71,6 +71,16 @@ refreshkeys() { \
 			;;
 		*)
 			dialog --infobox "Enabling Arch Repositories..." 4 40
+			if ! grep -q "^\[universe\]" /etc/pacman.conf; then
+				echo "[universe]
+Server = https://universe.artixlinux.org/\$arch
+Server = https://mirror1.artixlinux.org/universe/\$arch
+Server = https://mirror.pascalpuffke.de/artix-universe/\$arch
+Server = https://artixlinux.qontinuum.space/artixlinux/universe/os/\$arch
+Server = https://mirror1.cl.netactuate.com/artix/universe/\$arch
+Server = https://ftp.crifo.org/artix-universe/" >> /etc/pacman.conf
+				pacman -Sy
+			fi
 			pacman --noconfirm --needed -S artix-keyring artix-archlinux-support >/dev/null 2>&1
 			for repo in extra community; do
 				grep -q "^\[$repo\]" /etc/pacman.conf ||


### PR DESCRIPTION
I got an error when running larbs.sh on a fresh Artix install.
     Error: "Error automatically refreshing Arch keyring. Consider doing so manually."
The source of the error was the script being unable to find 'artix-archlinux-support' because it has recently moved into the [universe] repository which is not added to Artix's pacman.conf by default on a fresh install.

I added an if statement to larbs.sh which adds the [universe] repo to pacman.conf. This has been verified on a new Artix install as resolving the error.