### PR TITLE
git clone wrapper for minimal & silent clones

### DIFF
--- a/larbs.sh
+++ b/larbs.sh
@@ -23,6 +23,11 @@ esac done
 
 installpkg(){ pacman --noconfirm --needed -S "$1" >/dev/null 2>&1 ;}
 
+gitclonefast() {
+	# Wrapper around `git clone` for minimal and silent clone.
+	git clone --depth 1 --single-branch --no-tags -q "${@}"
+}
+
 error() { printf "%s\n" "$1" >&2; exit 1; }
 
 welcomemsg() { \
@@ -100,8 +105,8 @@ manualinstall() { # Installs $1 manually. Used only for AUR helper here.
 	# Should be run after repodir is created and var is set.
 	dialog --infobox "Installing \"$1\", an AUR helper..." 4 50
 	sudo -u "$name" mkdir -p "$repodir/$1"
-	sudo -u "$name" git clone --depth 1 "https://aur.archlinux.org/$1.git" "$repodir/$1" >/dev/null 2>&1 ||
-		{ cd "$repodir/$1" || return 1 ; sudo -u "$name" git pull --force origin master;}
+	sudo -u "$name" gitclonefast "https://aur.archlinux.org/$1.git" "$repodir/$1" \
+		|| { cd "$repodir/$1" || return 1 ; sudo -u "$name" git pull --force origin master;}
 	cd "$repodir/$1"
 	sudo -u "$name" -D "$repodir/$1" makepkg --noconfirm -si >/dev/null 2>&1 || return 1
 }
@@ -115,7 +120,7 @@ gitmakeinstall() {
 	progname="$(basename "$1" .git)"
 	dir="$repodir/$progname"
 	dialog --title "LARBS Installation" --infobox "Installing \`$progname\` ($n of $total) via \`git\` and \`make\`. $(basename "$1") $2" 5 70
-	sudo -u "$name" git clone --depth 1 "$1" "$dir" >/dev/null 2>&1 || { cd "$dir" || return 1 ; sudo -u "$name" git pull --force origin master;}
+	sudo -u "$name" gitclonefast "$1" "$dir" || { cd "$dir" || return 1 ; sudo -u "$name" git pull --force origin master;}
 	cd "$dir" || exit 1
 	make >/dev/null 2>&1
 	make install >/dev/null 2>&1
@@ -154,7 +159,7 @@ putgitrepo() { # Downloads a gitrepo $1 and places the files in $2 only overwrit
 	dir=$(mktemp -d)
 	[ ! -d "$2" ] && mkdir -p "$2"
 	chown "$name":wheel "$dir" "$2"
-	sudo -u "$name" git clone --recursive -b "$branch" --depth 1 --recurse-submodules "$1" "$dir" >/dev/null 2>&1
+	sudo -u "$name" gitclonefast --recursive -b "$branch" --recurse-submodules "$1" "$dir"
 	sudo -u "$name" cp -rfT "$dir" "$2"
 	}
 


### PR DESCRIPTION
- Removed a few `>/dev/null 2>&1`'s in favour of `git clone -q`.