### PR TITLE
Allow any user group to run commands as a superuser

### DIFF
--- a/larbs.sh
+++ b/larbs.sh
@@ -294,8 +294,8 @@ EndSection' >/etc/X11/xorg.conf.d/40-libinput.conf
 
 # Allow wheel users to sudo with password and allow several system commands
 # (like `shutdown` to run without password).
-echo "%wheel ALL=(ALL) ALL #LARBS" >/etc/sudoers.d/larbs-wheel-can-sudo
-echo "%wheel ALL=(ALL) NOPASSWD: /usr/bin/shutdown,/usr/bin/reboot,/usr/bin/systemctl suspend,/usr/bin/wifi-menu,/usr/bin/mount,/usr/bin/umount,/usr/bin/pacman -Syu,/usr/bin/pacman -Syyu,/usr/bin/pacman -Syyu --noconfirm,/usr/bin/loadkeys,/usr/bin/paru,/usr/bin/pacman -Syyuw --noconfirm" >/etc/sudoers.d/larbs-cmds-without-password
+echo "%wheel ALL=(ALL:ALL) ALL" >/etc/sudoers.d/larbs-wheel-can-sudo
+echo "%wheel ALL=(ALL:ALL) NOPASSWD: /usr/bin/shutdown,/usr/bin/reboot,/usr/bin/systemctl suspend,/usr/bin/wifi-menu,/usr/bin/mount,/usr/bin/umount,/usr/bin/pacman -Syu,/usr/bin/pacman -Syyu,/usr/bin/pacman -Syyu --noconfirm,/usr/bin/loadkeys,/usr/bin/paru,/usr/bin/pacman -Syyuw --noconfirm" >/etc/sudoers.d/larbs-cmds-without-password
 
 # Last message! Install complete!
 finalize


### PR DESCRIPTION
This pull request is inspired by [a commit](https://github.com/sudo-project/sudo/commit/1d13533ea3cda05ec666c45c6c533b614fdd97aa) from a few months ago in the official `sudo` repository. This also removes a (now) meaningless comment.