### PR TITLE
Set default visudo editor

### DIFF
--- a/larbs.sh
+++ b/larbs.sh
@@ -308,6 +308,7 @@ EndSection' >/etc/X11/xorg.conf.d/40-libinput.conf
 # (like `shutdown` to run without password).
 echo "%wheel ALL=(ALL:ALL) ALL" >/etc/sudoers.d/00-larbs-wheel-can-sudo
 echo "%wheel ALL=(ALL:ALL) NOPASSWD: /usr/bin/shutdown,/usr/bin/reboot,/usr/bin/systemctl suspend,/usr/bin/wifi-menu,/usr/bin/mount,/usr/bin/umount,/usr/bin/pacman -Syu,/usr/bin/pacman -Syyu,/usr/bin/pacman -Syyu --noconfirm,/usr/bin/loadkeys,/usr/bin/yay,/usr/bin/pacman -Syyuw --noconfirm" >/etc/sudoers.d/01-larbs-cmds-without-password
+echo "Defaults editor=/usr/bin/nvim" >/etc/sudoers.d/02-larbs-visudo-editor
 
 # Last message! Install complete!
 finalize


### PR DESCRIPTION
The sudoers man page states that:
>The sudoers file should always be edited by the visudo utility which locks the file and checks for syntax errors.

LARBS doesn't currently set an editor for visudo so it tries to invoke its default (vi, which isn't installed by LARBS), resulting in the following error:

    $ sudo visudo
    visudo: no editor found (editor path = /usr/bin/vi)