### PR TITLE
remove pamixer from dependencies

### DIFF
--- a/progs.csv
+++ b/progs.csv
@@ -36,7 +36,6 @@ A,librewolf-bin,"the default browser of LARBS which also comes with ad-blocking 
 ,wireplumber,"is the audio system."
 ,pipewire-pulse,"gives pipewire compatibility with PulseAudio programs."
 ,pulsemixer,"is an audio controller."
-,pamixer,"is a command-line audio interface."
 A,sc-im,"is an Excel-like terminal spreadsheet manager."
 ,maim,"can take quick screenshots at your request."
 A,abook,"is an offline addressbook usable by neomutt."


### PR DESCRIPTION
unnecessary since volume binds now use wpctl ([dwm#219](https://github.com/LukeSmithxyz/dwm/pull/219))