### PR TITLE
ntpdate is deprecating, so replace it with ntpd

### DIFF
--- a/larbs.sh
+++ b/larbs.sh
@@ -239,7 +239,7 @@ done
 
 whiptail --title "LARBS Installation" \
 	--infobox "Synchronizing system time to ensure successful and secure installation of software..." 8 70
-ntpdate 0.us.pool.ntp.org >/dev/null 2>&1
+ntpd -q -g >/dev/null 2>&1
 
 adduserandpass || error "Error adding username and/or password."
 


### PR DESCRIPTION
From the Gentoo Wiki:

`ntp-client` utilizes the deprecated `ntpdate` and is not recommended as a long term solution. Use `ntpd` and `sntp` instead.

The Gentoo wiki recommends synchronizing time by running
`ntpd -q -g`


Some useful links:
https://wiki.gentoo.org/wiki/Ntp#Ntp-client
https://support.ntp.org/Dev/DeprecatingNtpdate