### PR TITLE
Also update .*-git packages by default

### DIFF
--- a/static/larbs.sh
+++ b/static/larbs.sh
@@ -309,7 +309,10 @@ sed -Ei "s/^#(ParallelDownloads).*/\1 = 5/;/^#Color$/s/#//" /etc/pacman.conf
 # Use all cores for compilation.
 sed -i "s/-j2/-j$(nproc)/;/^#MAKEFLAGS/s/^#//" /etc/makepkg.conf
 
-manualinstall yay || error "Failed to install AUR helper."
+manualinstall $aurhelper || error "Failed to install AUR helper."
+
+# Make sure .*-git AUR packages get updated automatically.
+$aurhelper -Y --save --devel
 
 # The command that does all the installing. Reads the progs.csv file and
 # installs each needed program the way required. Be sure to run this only after


### PR DESCRIPTION
There are a couple of `.*-git` packages installed from the AUR, like lf-git and mutt-wizard-git, but by default yay doesn't update them when updating packages, making them outdated after a while. This command edits yay's configuration to always update these packages as well if updates are available for them.

The `-Y` just makes sure that yay only edits the configuration file, but doesn't run an update.