### PR TITLE
fix profile sed

### DIFF
--- a/static/larbs.sh
+++ b/static/larbs.sh
@@ -356,7 +356,7 @@ profilesini="$browserdir/profiles.ini"
 # Start librewolf headless so it generates a profile. Then get that profile in a variable.
 sudo -u "$name" librewolf --headless >/dev/null 2>&1 &
 sleep 1
-profile="$(sed -n "/Default=.*.default-release/ s/.*=//p" "$profilesini")"
+profile="$(sed -n "/Default=.*.default-default/ s/.*=//p" "$profilesini")"
 pdir="$browserdir/$profile"
 
 [ -d "$pdir" ] && makeuserjs


### PR DESCRIPTION
arkenfox and installffaddons doesn't work since it cant find the profile directory. on the latest librewolf releases it should look for default-default folder instead of default-release