### PR TITLE
Install dash and make it the default #!/bin/sh symlink.

### DIFF
--- a/static/larbs.sh
+++ b/static/larbs.sh
@@ -275,7 +275,7 @@ preinstallmsg || error "User exited."
 refreshkeys ||
 	error "Error automatically refreshing Arch keyring. Consider doing so manually."
 
-for x in curl ca-certificates base-devel git ntp zsh; do
+for x in curl ca-certificates base-devel git ntp zsh dash; do
 	whiptail --title "LARBS Installation" \
 		--infobox "Installing \`$x\` which is required to install and configure other programs." 8 70
 	installpkg "$x"
@@ -329,6 +329,9 @@ chsh -s /bin/zsh "$name" >/dev/null 2>&1
 sudo -u "$name" mkdir -p "/home/$name/.cache/zsh/"
 sudo -u "$name" mkdir -p "/home/$name/.config/abook/"
 sudo -u "$name" mkdir -p "/home/$name/.config/mpd/playlists/"
+
+# Make dash the default #!/bin/sh symlink.
+ln -sfT /bin/dash /bin/sh >/dev/null 2>&1
 
 # dbus UUID must be generated for Artix runit.
 dbus-uuidgen >/var/lib/dbus/machine-id


### PR DESCRIPTION
Luke Smith Video: [Bash is Bloated!](https://youtu.be/UnbmwxYi18I?si=kwnfgnOATWfmvGeU)

In the linked video Luke has **Dash** symlinked to **/bin/sh**.

Extra Information for people:

- Dash is much faster than Bash especially for the execution. 
- It uses much less resources. 
- It's very minimal. 
- It's POSIX compliant and therefore portable.
- It's more secure.

We have `#!/bin/bash` exclusively for the needed scripts so there won't be any problems. 