### PR TITLE
Fix manualinstall, delete temporary file

### DIFF
--- a/static/larbs.sh
+++ b/static/larbs.sh
@@ -293,7 +293,7 @@ adduserandpass || error "Error adding username and/or password."
 # in a fakeroot environment, this is required for all builds with AUR.
 trap 'rm -f /etc/sudoers.d/larbs-temp' HUP INT QUIT TERM PWR EXIT
 echo "%wheel ALL=(ALL) NOPASSWD: ALL
-Defaults:%wheel runcwd=*" >/etc/sudoers.d/larbs-temp
+Defaults:%wheel,root runcwd=*" >/etc/sudoers.d/larbs-temp
 
 # Make pacman colorful, concurrent downloads and Pacman eye-candy.
 grep -q "ILoveCandy" /etc/pacman.conf || sed -i "/#VerbosePkgLists/a ILoveCandy" /etc/pacman.conf
@@ -374,6 +374,9 @@ echo "%wheel ALL=(ALL:ALL) NOPASSWD: /usr/bin/shutdown,/usr/bin/reboot,/usr/bin/
 echo "Defaults editor=/usr/bin/nvim" >/etc/sudoers.d/02-larbs-visudo-editor
 mkdir -p /etc/sysctl.d
 echo "kernel.dmesg_restrict = 0" > /etc/sysctl.d/dmesg.conf
+
+# Cleanup
+rm -f /etc/sudoers.d/larbs-temp
 
 # Last message! Install complete!
 finalize


### PR DESCRIPTION
This is a follow-up to #538, since 0da6e30 didn't fix the issue when installing as root.

A cleanup section has been added to delete temporary resources, in the future I'd like to make it a function.