### PR TITLE
install x server missing dependency

### DIFF
--- a/static/progs.csv
+++ b/static/progs.csv
@@ -2,6 +2,7 @@
 ,xorg-server,"is the graphical server. This first one may take a while as it pulls many other dependencies first on clean installs."
 ,xorg-xwininfo,"allows querying information about windows."
 ,xorg-xinit,"starts the graphical server."
+,xorg-xset,"utility for configuring and ajusting X server"
 ,polkit,"manages user policies."
 ,libertinus-font,"provides the sans and serif fonts for LARBS."
 ,ttf-font-awesome,"provides extended glyph support."


### PR DESCRIPTION
When running `startx` on a fresh installation, an error occurs indicating that the `xset` command is not found. Therefore, I am adding the `xorg-xset` package to resolve this issue.