### PR TITLE
fix multiple dbus instances on arch (systemd) based system

### DIFF
--- a/static/larbs.sh
+++ b/static/larbs.sh
@@ -351,7 +351,8 @@ ln -sfT /bin/dash /bin/sh >/dev/null 2>&1
 dbus-uuidgen >/var/lib/dbus/machine-id
 
 # Use system notifications for Brave on Artix
-echo "export \$(dbus-launch)" >/etc/profile.d/dbus.sh
+# Only do it when systemd is not present
+[ "$(readlink -f /sbin/init)" != "/usr/lib/systemd/systemd" ] && echo "export \$(dbus-launch)" >/etc/profile.d/dbus.sh
 
 # Enable tap to click
 [ ! -f /etc/X11/xorg.conf.d/40-libinput.conf ] && printf 'Section "InputClass"


### PR DESCRIPTION
Brave browser was very slow to open on arch linux. After some digging I found out that it was happening because there were multiple dbus instance running. To solve that only add dbus entry in profile directory if systemd is not there. I think systemd automatically does it