### PR TITLE
Replaced lf-git with lf

### DIFF
--- a/static/progs.csv
+++ b/static/progs.csv
@@ -7,7 +7,7 @@
 ,otf-libertinus,"provides the sans and serif fonts for LARBS."
 ,ttf-font-awesome,"provides extended glyph support."
 ,ttf-dejavu,"properly displays emojis."
-A,lf-git,"is an extensive terminal file manager that everyone likes."
+,lf,"is an extensive terminal file manager that everyone likes."
 ,ueberzugpp,"enables previews in the lf file manager."
 ,bc,"is a mathematics language used for the dropdown calculator."
 ,xcompmgr,"is for transparency and removing screen-tearing."


### PR DESCRIPTION
Any reason lf-git was used instead of lf? Seems like unnecessary AUR package.